### PR TITLE
chore: add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "fengyuanchen/cropper",
+  "version": "3.1.5",
+  "license": "MIT",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/fengyuanchen/cropper"
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for composer. Users can then install it via `composer require fengyuanchen/cropper`.

It has to be [added to packagist](https://packagist.org/packages/submit).